### PR TITLE
Typo: extra close paren

### DIFF
--- a/simple-callout.html
+++ b/simple-callout.html
@@ -26,7 +26,7 @@
                  font-smoothing: antialiased;
       }
 
-      :host([hidden])) {
+      :host([hidden]) {
         display: none;
       }
 


### PR DESCRIPTION
extra close paren in the stylesheet