### PR TITLE
Fix extra closing parenthesis which breaks display

### DIFF
--- a/simple-callout.html
+++ b/simple-callout.html
@@ -26,7 +26,7 @@
                  font-smoothing: antialiased;
       }
 
-      :host([hidden])) {
+      :host([hidden]) {
         display: none;
       }
 


### PR DESCRIPTION
The extra closing parenthesis caused the item to still consume space when hidden.